### PR TITLE
Feature/dom xss hash query

### DIFF
--- a/cases/address-dom/hash.json
+++ b/cases/address-dom/hash.json
@@ -1,0 +1,17 @@
+{
+  "title": "Location Hash DOM XSS",
+  "description": "This test demonstrates a DOM-based XSS vulnerability via the location hash. Input from window.location.hash is inserted directly into the DOM without sanitization.",
+  "objectives": [
+    "Understand how window.location.hash can be abused.",
+    "Trigger a JavaScript execution using a crafted hash."
+  ],
+  "hints": [
+    "Try injecting an <img> tag with onerror attribute.",
+    "Observe how the hash is rendered in the page DOM."
+  ],
+  "difficulty": "medium",
+  "category": "address-dom",
+  "risk": "medium",
+  "status": "active",
+  "body": "<div>Hash content:</div><div id='output'></div><script>const hash = decodeURIComponent(window.location.hash.substring(1));document.getElementById('output').innerHTML = hash;</script>"
+}

--- a/cases/address-dom/query-dump.json
+++ b/cases/address-dom/query-dump.json
@@ -1,0 +1,17 @@
+{
+  "title": "Query Dump DOM XSS",
+  "description": "This test demonstrates DOM XSS by dumping all URL query parameters into the DOM unsanitized.",
+  "objectives": [
+    "See how dumping query parameters can be dangerous.",
+    "Inject payloads into any query parameter to trigger XSS."
+  ],
+  "hints": [
+    "Try using <img src=x onerror=alert(1)> as any value.",
+    "Observe how all query params are rendered with innerHTML."
+  ],
+  "difficulty": "medium",
+  "category": "address-dom",
+  "risk": "medium",
+  "status": "active",
+  "body": "<div>Query Parameters:</div><div id='query-output'></div><script>const params = Object.fromEntries(new URLSearchParams(location.search));document.getElementById('query-output').innerHTML = JSON.stringify(params);</script>"
+}

--- a/cases/reflected/search_form.json
+++ b/cases/reflected/search_form.json
@@ -1,0 +1,18 @@
+{
+  "title": "Basic Reflected XSS - Search Form",
+  "description": "This test demonstrates a simple reflected XSS vulnerability in a search form. User input from URL parameters is directly reflected in the page without proper sanitization, allowing attackers to inject malicious scripts.",
+  "objectives": [
+    "Identify the reflected XSS vector in the search parameter.",
+    "Craft a malicious URL to execute JavaScript code.",
+    "Understand how reflected XSS can be used for phishing attacks."
+  ],
+  "hints": [
+    "Try injecting a <script> tag in the search parameter.",
+    "Check how the search term is displayed on the page.",
+    "Look at the URL parameters after submitting the form."
+  ],  "difficulty": "beginner",
+  "category": "reflected",
+  "risk": "medium",
+  "status": "active",
+  "body": "<div class='search-container'><h2>Arama Motoru</h2><form method='GET' action=''><label for='q'>Arama Terimi:</label><input type='text' id='q' name='q' placeholder='Arama yapmak için bir terim girin...'><button type='submit'>Ara</button></form><div id='results'><script>const urlParams = new URLSearchParams(window.location.search);const query = urlParams.get('q');if (query) { document.getElementById('results').innerHTML = '<h3>Arama Sonuçları:</h3><p>\"' + query + '\" için sonuçlar:</p><div class=\"search-results\">Sonuç bulunamadı.</div>'; }</script></div></div><style>.search-container { max-width: 600px; margin: 20px auto; padding: 20px; border: 1px solid #ddd; border-radius: 8px; } .search-container h2 { color: #333; margin-bottom: 20px; } .search-container form { margin-bottom: 20px; } .search-container label { display: block; margin-bottom: 5px; font-weight: bold; } .search-container input[type='text'] { width: 70%; padding: 10px; border: 1px solid #ccc; border-radius: 4px; font-size: 16px; } .search-container button { padding: 10px 20px; background-color: #007bff; color: white; border: none; border-radius: 4px; cursor: pointer; margin-left: 10px; } .search-container button:hover { background-color: #0056b3; } #results { margin-top: 20px; padding: 15px; background-color: #f9f9f9; border-left: 4px solid #007bff; } .search-results { margin-top: 10px; color: #666; }</style>"
+}

--- a/templates/index_cases.json
+++ b/templates/index_cases.json
@@ -366,5 +366,23 @@
       ],
       "resources": []
     }
+  },
+  
+  {
+    "title": "Location Hash DOM XSS",
+    "path": "address-dom/hash",
+    "difficulty": "medium",
+    "category": "address-dom",
+    "risk": "medium",
+    "status": "active"
+  },
+  {
+    "title": "Query Dump DOM XSS",
+    "path": "address-dom/query-dump",
+    "difficulty": "medium",
+    "category": "address-dom",
+    "risk": "medium",
+    "status": "active"
   }
+
 ]


### PR DESCRIPTION
Added two new DOM-based XSS cases:

Hash DOM XSS
Uses window.location.hash to inject malicious HTML directly into the DOM.

Query Dump DOM XSS
Demonstrates how dumping all query parameters unsanitized into the DOM can cause XSS.

Both cases are placed under the address-dom category and marked as medium difficulty & risk.