### PR TITLE
feat: add 5 firing-range inspired HTML context reflected XSS cases

### DIFF
--- a/cases/reflected/parameter-attribute-double-quoted.json
+++ b/cases/reflected/parameter-attribute-double-quoted.json
@@ -1,0 +1,21 @@
+{
+    "title": "Parameter - Attribute Double Quoted",
+    "description": "The parameter is echoed in an HTML attribute, double quoted. i.e. <code>&lt;div data-value=\"%q\"&gt;</code>. The attacker must first break out of the double quotes.",
+    "category": "reflected",
+    "difficulty": "Medium",
+    "risk": "High",
+    "status": "Active",
+    "type": "parameter-attribute-double-quoted",
+
+    "objectives": [
+        "Break out of the double-quoted attribute value.",
+        "Inject a new event handler attribute after escaping the quotes.",
+        "Understand how quoting affects the difficulty of attribute-based XSS."
+    ],
+
+    "hints": [
+        "The context is: <code>&lt;div data-value=\"[INPUT]\"&gt;</code>.",
+        "You need a double quote to close the attribute, then inject new attributes.",
+        "Try: <code>\" onfocus=\"alert(1)\" autofocus tabindex=\"1</code>"
+    ]
+}

--- a/cases/reflected/parameter-attribute-double-quoted.json
+++ b/cases/reflected/parameter-attribute-double-quoted.json
@@ -5,14 +5,13 @@
     "difficulty": "Medium",
     "risk": "High",
     "status": "Active",
-    "type": "parameter-attribute-double-quoted",
-
+    "type": "php",
+    "php": "<?php\n$input = isset($_GET['q']) ? $_GET['q'] : 'default';\n?>\n<!DOCTYPE html>\n<html>\n<body>\n    <h3>Parameter - Attribute Double Quoted</h3>\n    <p>The <code>q</code> parameter is echoed in a double-quoted HTML attribute.</p>\n    <p>Param: <code>?q=</code></p>\n\n    <div style=\"margin: 20px 0; padding: 20px; border: 1px dashed #555; border-radius: 8px; background: rgba(255,255,255,0.02);\">\n        <p style=\"color: #888; font-size: 0.85em; margin-bottom: 10px;\">⬇️ Reflected output (inspect the element below):</p>\n        <!-- INJECTION POINT: double-quoted attribute -->\n        <div id=\"attrQuotedTarget\" data-value=\"<?php echo $input; ?>\" style=\"padding: 15px; border: 1px solid #444; border-radius: 6px; background: rgba(0,255,157,0.05);\">\n            This element has a double-quoted <code>data-value</code> attribute.\n            <br><em>Inspect this element to see the injection point.</em>\n        </div>\n    </div>\n</body>\n</html>",
     "objectives": [
         "Break out of the double-quoted attribute value.",
         "Inject a new event handler attribute after escaping the quotes.",
         "Understand how quoting affects the difficulty of attribute-based XSS."
     ],
-
     "hints": [
         "The context is: <code>&lt;div data-value=\"[INPUT]\"&gt;</code>.",
         "You need a double quote to close the attribute, then inject new attributes.",

--- a/cases/reflected/parameter-attribute-unquoted.json
+++ b/cases/reflected/parameter-attribute-unquoted.json
@@ -5,14 +5,13 @@
     "difficulty": "Easy",
     "risk": "High",
     "status": "Active",
-    "type": "parameter-attribute-unquoted",
-
+    "type": "php",
+    "php": "<?php\n$input = isset($_GET['q']) ? $_GET['q'] : 'default';\n?>\n<!DOCTYPE html>\n<html>\n<body>\n    <h3>Parameter - Attribute Unquoted</h3>\n    <p>The <code>q</code> parameter is echoed in an HTML attribute without quotes.</p>\n    <p>Param: <code>?q=</code></p>\n\n    <div style=\"margin: 20px 0; padding: 20px; border: 1px dashed #555; border-radius: 8px; background: rgba(255,255,255,0.02);\">\n        <p style=\"color: #888; font-size: 0.85em; margin-bottom: 10px;\">⬇️ Reflected output (inspect the element below):</p>\n        <!-- INJECTION POINT: unquoted attribute -->\n        <div id=\"attrTarget\" data-value=<?php echo $input; ?> style=\"padding: 15px; border: 1px solid #444; border-radius: 6px; background: rgba(0,255,157,0.05);\">\n            This element has an unquoted <code>data-value</code> attribute.\n            <br><em>Inspect this element to see the injection point.</em>\n        </div>\n    </div>\n</body>\n</html>",
     "objectives": [
         "Inject a new attribute by adding a space to break out of the current value.",
         "Add an event handler attribute like <code>onmouseover</code> or <code>onfocus</code>.",
         "Understand the difference between quoted and unquoted attribute injection."
     ],
-
     "hints": [
         "The context is: <code>&lt;div data-value=[INPUT]&gt;</code> with no quotes.",
         "A space character ends the attribute value and allows new attributes.",

--- a/cases/reflected/parameter-attribute-unquoted.json
+++ b/cases/reflected/parameter-attribute-unquoted.json
@@ -1,0 +1,21 @@
+{
+    "title": "Parameter - Attribute Unquoted",
+    "description": "The parameter is echoed in an HTML attribute, unquoted. i.e. <code>&lt;div data-value=%q&gt;</code>. The attacker can inject new attributes or event handlers by using a space.",
+    "category": "reflected",
+    "difficulty": "Easy",
+    "risk": "High",
+    "status": "Active",
+    "type": "parameter-attribute-unquoted",
+
+    "objectives": [
+        "Inject a new attribute by adding a space to break out of the current value.",
+        "Add an event handler attribute like <code>onmouseover</code> or <code>onfocus</code>.",
+        "Understand the difference between quoted and unquoted attribute injection."
+    ],
+
+    "hints": [
+        "The context is: <code>&lt;div data-value=[INPUT]&gt;</code> with no quotes.",
+        "A space character ends the attribute value and allows new attributes.",
+        "Try: <code>x onfocus=alert(1) autofocus tabindex=1</code>"
+    ]
+}

--- a/cases/reflected/parameter-body-comment.json
+++ b/cases/reflected/parameter-body-comment.json
@@ -1,0 +1,21 @@
+{
+    "title": "Parameter - Body HTML Comment",
+    "description": "The parameter is echoed inside an HTML comment in the HTML BODY. The attacker must break out of the comment to inject executable content.",
+    "category": "reflected",
+    "difficulty": "Medium",
+    "risk": "High",
+    "status": "Active",
+    "type": "parameter-body-comment",
+
+    "objectives": [
+        "Break out of the HTML comment context using <code>--&gt;</code>.",
+        "Inject a script tag after escaping the comment.",
+        "Understand how HTML comments can be exploited if user input is reflected inside them."
+    ],
+
+    "hints": [
+        "The input is placed inside <code>&lt;!-- [INPUT] --&gt;</code>.",
+        "HTML comments end with <code>--&gt;</code>. Close the comment first.",
+        "Try: <code>--&gt;&lt;script&gt;alert(1)&lt;/script&gt;&lt;!--</code>"
+    ]
+}

--- a/cases/reflected/parameter-body-comment.json
+++ b/cases/reflected/parameter-body-comment.json
@@ -5,14 +5,13 @@
     "difficulty": "Medium",
     "risk": "High",
     "status": "Active",
-    "type": "parameter-body-comment",
-
+    "type": "php",
+    "php": "<?php\n$input = isset($_GET['q']) ? $_GET['q'] : 'This is a comment';\n?>\n<!DOCTYPE html>\n<html>\n<body>\n    <h3>Parameter - Body HTML Comment</h3>\n    <p>The <code>q</code> parameter is echoed inside an HTML comment in the body.</p>\n    <p>Param: <code>?q=</code></p>\n\n    <div style=\"margin: 20px 0; padding: 20px; border: 1px dashed #555; border-radius: 8px; background: rgba(255,255,255,0.02);\">\n        <p style=\"color: #888; font-size: 0.85em; margin-bottom: 10px;\">⬇️ Reflected output (hidden in HTML comment — view page source):</p>\n        <!-- INJECTION POINT: echoes inside HTML comment -->\n        <!-- <?php echo $input; ?> -->\n        <p style=\"color: #666; font-style: italic;\">The input is inside an HTML comment. Right-click → View Page Source to see it.</p>\n    </div>\n</body>\n</html>",
     "objectives": [
         "Break out of the HTML comment context using <code>--&gt;</code>.",
         "Inject a script tag after escaping the comment.",
         "Understand how HTML comments can be exploited if user input is reflected inside them."
     ],
-
     "hints": [
         "The input is placed inside <code>&lt;!-- [INPUT] --&gt;</code>.",
         "HTML comments end with <code>--&gt;</code>. Close the comment first.",

--- a/cases/reflected/parameter-body.json
+++ b/cases/reflected/parameter-body.json
@@ -5,14 +5,13 @@
     "difficulty": "Beginner",
     "risk": "High",
     "status": "Active",
-    "type": "parameter-body",
-
+    "type": "php",
+    "php": "<?php\n$input = isset($_GET['q']) ? $_GET['q'] : 'Hello World';\n?>\n<!DOCTYPE html>\n<html>\n<body>\n    <h3>Parameter - Body Injection</h3>\n    <p>The <code>q</code> parameter is echoed directly within the <code>&lt;body&gt;</code> without any escaping.</p>\n    <p>Param: <code>?q=</code></p>\n\n    <div class=\"result\" style=\"margin: 20px 0; padding: 20px; border: 1px dashed #555; border-radius: 8px; background: rgba(255,255,255,0.02);\">\n        <p style=\"color: #888; font-size: 0.85em; margin-bottom: 10px;\">⬇️ Reflected output:</p>\n        <!-- INJECTION POINT: echoes directly in body -->\n        <?php echo $input; ?>\n    </div>\n</body>\n</html>",
     "objectives": [
         "Inject HTML tags directly into the page body.",
         "Execute JavaScript via a <code>&lt;script&gt;</code> tag injection.",
         "Understand why unescaped output in the body context is dangerous."
     ],
-
     "hints": [
         "Your input appears directly inside <code>&lt;body&gt;</code>. Any HTML you type will be rendered.",
         "Try injecting: <code>&lt;script&gt;alert(1)&lt;/script&gt;</code>",

--- a/cases/reflected/parameter-body.json
+++ b/cases/reflected/parameter-body.json
@@ -1,0 +1,21 @@
+{
+    "title": "Parameter - Body",
+    "description": "The parameter is echoed within the main BODY tag. No server-side escaping is performed.",
+    "category": "reflected",
+    "difficulty": "Beginner",
+    "risk": "High",
+    "status": "Active",
+    "type": "parameter-body",
+
+    "objectives": [
+        "Inject HTML tags directly into the page body.",
+        "Execute JavaScript via a <code>&lt;script&gt;</code> tag injection.",
+        "Understand why unescaped output in the body context is dangerous."
+    ],
+
+    "hints": [
+        "Your input appears directly inside <code>&lt;body&gt;</code>. Any HTML you type will be rendered.",
+        "Try injecting: <code>&lt;script&gt;alert(1)&lt;/script&gt;</code>",
+        "You can also use event handlers: <code>&lt;img src=x onerror=alert(1)&gt;</code>"
+    ]
+}

--- a/cases/reflected/parameter-title.json
+++ b/cases/reflected/parameter-title.json
@@ -1,0 +1,21 @@
+{
+    "title": "Parameter - Title",
+    "description": "The parameter is echoed within the TITLE tag. The attacker must break out of the title context to execute scripts.",
+    "category": "reflected",
+    "difficulty": "Easy",
+    "risk": "High",
+    "status": "Active",
+    "type": "parameter-title",
+
+    "objectives": [
+        "Break out of the <code>&lt;title&gt;</code> tag to inject HTML.",
+        "Execute JavaScript by closing the title tag and injecting a script.",
+        "Understand how injection in non-visible HTML elements can still lead to XSS."
+    ],
+
+    "hints": [
+        "The input is placed inside <code>&lt;title&gt;[INPUT]&lt;/title&gt;</code>.",
+        "Close the title tag first, then inject your payload.",
+        "Try: <code>&lt;/title&gt;&lt;script&gt;alert(1)&lt;/script&gt;</code>"
+    ]
+}

--- a/cases/reflected/parameter-title.json
+++ b/cases/reflected/parameter-title.json
@@ -5,14 +5,13 @@
     "difficulty": "Easy",
     "risk": "High",
     "status": "Active",
-    "type": "parameter-title",
-
+    "type": "php",
+    "php": "<?php\n$input = isset($_GET['q']) ? $_GET['q'] : 'XSStrange - Title Injection';\n?>\n<!DOCTYPE html>\n<html>\n<head>\n    <!-- INJECTION POINT: echoes inside <title> tag -->\n    <title><?php echo $input; ?></title>\n</head>\n<body>\n    <h3>Parameter - Title Tag Injection</h3>\n    <p>The <code>q</code> parameter is echoed within the <code>&lt;title&gt;</code> tag.</p>\n    <p>Param: <code>?q=</code></p>\n\n    <div style=\"margin: 20px 0; padding: 20px; border: 1px dashed #555; border-radius: 8px; background: rgba(255,255,255,0.02);\">\n        <p style=\"color: #888; font-size: 0.85em; margin-bottom: 10px;\">⬇️ The parameter is injected into the <code>&lt;title&gt;</code> tag above.</p>\n        <p>Current title value: <code><?php echo htmlspecialchars($input, ENT_QUOTES, 'UTF-8'); ?></code></p>\n    </div>\n</body>\n</html>",
     "objectives": [
         "Break out of the <code>&lt;title&gt;</code> tag to inject HTML.",
         "Execute JavaScript by closing the title tag and injecting a script.",
         "Understand how injection in non-visible HTML elements can still lead to XSS."
     ],
-
     "hints": [
         "The input is placed inside <code>&lt;title&gt;[INPUT]&lt;/title&gt;</code>.",
         "Close the title tag first, then inject your payload.",

--- a/templates/index_cases.json
+++ b/templates/index_cases.json
@@ -59,7 +59,12 @@
         "js-eval",
         "js-quoted",
         "js-unquoted",
-        "js-single-quoted"
+        "js-single-quoted",
+        "parameter-body",
+        "parameter-title",
+        "parameter-body-comment",
+        "parameter-attribute-unquoted",
+        "parameter-attribute-double-quoted"
       ],
       "resources": []
     }

--- a/templates/template_pages/case_template.html
+++ b/templates/template_pages/case_template.html
@@ -142,7 +142,7 @@
                     {{ description }}
                 </div>
 
-                {% if type and ((type|lower).startswith('css') or (type|lower).startswith('parameter-')) %}
+                {% if type and (type|lower).startswith('css') %}
                 <div class="interaction-box">
                     <h4 style="margin-top: 0; margin-bottom: 15px; display:flex; align-items:center; justify-content:space-between;">
                         <span><i class="fas fa-flask"></i> Test Your Payload</span>
@@ -174,7 +174,7 @@
                     
                     <div class="edu-note">
                         <i class="fas fa-info-circle" style="color: #007bff; margin-right: 5px;"></i> 
-                        <strong>How it works:</strong> The text you type above is appended to the URL as a GET parameter (<code>?q=...</code>). The server then takes this parameter and inserts it into the HTML below without any escaping.
+                        <strong>How it works:</strong> The text you type above is appended to the URL as a GET parameter (<code>?q=...</code>). The server then takes this parameter and inserts it into the CSS code below.
                     </div>
                 </div>
                 {% endif %}
@@ -227,65 +227,6 @@
                         </style>
 
                         <p id="cssFontTarget">This text will use the injected font-family.</p>
-
-                    {% elif type == "parameter-body" %}
-                        <h3>Body Injection</h3>
-                        <p>The <code>q</code> parameter is echoed directly within the <code>&lt;body&gt;</code> tag. No escaping is applied.</p>
-                        <p>Context: <code>&lt;body&gt; [INPUT] &lt;/body&gt;</code></p>
-
-                        <div style="margin: 20px 0; padding: 20px; border: 1px dashed #555; border-radius: 8px; background: rgba(255,255,255,0.02);">
-                            <p style="color: #888; font-size: 0.85em; margin-bottom: 10px;">⬇️ Reflected output:</p>
-                            {{ request.args.get('q', 'Hello World') | safe }}
-                        </div>
-
-                    {% elif type == "parameter-title" %}
-                        <h3>Title Tag Injection</h3>
-                        <p>The <code>q</code> parameter is echoed within the <code>&lt;title&gt;</code> tag. Check the browser tab to see the reflected value.</p>
-                        <p>Context: <code>&lt;title&gt; [INPUT] &lt;/title&gt;</code></p>
-
-                        <title>{{ request.args.get('q', 'XSStrange - Title Injection') | safe }}</title>
-
-                        <div style="margin: 20px 0; padding: 20px; border: 1px dashed #555; border-radius: 8px; background: rgba(255,255,255,0.02);">
-                            <p style="color: #888; font-size: 0.85em; margin-bottom: 10px;">⬇️ The parameter is injected into the <code>&lt;title&gt;</code> tag above. Check the browser tab title.</p>
-                            <p>Current title value: <code>{{ request.args.get('q', 'XSStrange - Title Injection') }}</code></p>
-                        </div>
-
-                    {% elif type == "parameter-body-comment" %}
-                        <h3>HTML Comment Injection</h3>
-                        <p>The <code>q</code> parameter is echoed inside an HTML comment in the body. The content is not visible, but it is in the source code.</p>
-                        <p>Context: <code>&lt;!-- [INPUT] --&gt;</code></p>
-
-                        <div style="margin: 20px 0; padding: 20px; border: 1px dashed #555; border-radius: 8px; background: rgba(255,255,255,0.02);">
-                            <p style="color: #888; font-size: 0.85em; margin-bottom: 10px;">⬇️ Reflected output (hidden in HTML comment — view page source):</p>
-                            <!-- {{ request.args.get('q', 'This is a comment') | safe }} -->
-                            <p style="color: #666; font-style: italic;">The input is inside an HTML comment. Right-click → View Page Source to see it.</p>
-                        </div>
-
-                    {% elif type == "parameter-attribute-unquoted" %}
-                        <h3>Unquoted Attribute Injection</h3>
-                        <p>The <code>q</code> parameter is echoed in an HTML attribute without quotes.</p>
-                        <p>Context: <code>&lt;div data-value=[INPUT]&gt;</code></p>
-
-                        <div style="margin: 20px 0; padding: 20px; border: 1px dashed #555; border-radius: 8px; background: rgba(255,255,255,0.02);">
-                            <p style="color: #888; font-size: 0.85em; margin-bottom: 10px;">⬇️ Reflected output (inspect the element below):</p>
-                            <div id="attrTarget" data-value={{ request.args.get('q', 'default') | safe }} style="padding: 15px; border: 1px solid #444; border-radius: 6px; background: rgba(0,255,157,0.05);">
-                                This element has <code>data-value={{ request.args.get('q', 'default') }}</code> (unquoted attribute).
-                                <br><em>Inspect this element to see the injection point.</em>
-                            </div>
-                        </div>
-
-                    {% elif type == "parameter-attribute-double-quoted" %}
-                        <h3>Double-Quoted Attribute Injection</h3>
-                        <p>The <code>q</code> parameter is echoed in a double-quoted HTML attribute.</p>
-                        <p>Context: <code>&lt;div data-value="[INPUT]"&gt;</code></p>
-
-                        <div style="margin: 20px 0; padding: 20px; border: 1px dashed #555; border-radius: 8px; background: rgba(255,255,255,0.02);">
-                            <p style="color: #888; font-size: 0.85em; margin-bottom: 10px;">⬇️ Reflected output (inspect the element below):</p>
-                            <div id="attrQuotedTarget" data-value="{{ request.args.get('q', 'default') | safe }}" style="padding: 15px; border: 1px solid #444; border-radius: 6px; background: rgba(0,255,157,0.05);">
-                                This element has <code>data-value="{{ request.args.get('q', 'default') }}"</code> (double-quoted attribute).
-                                <br><em>Inspect this element to see the injection point.</em>
-                            </div>
-                        </div>
 
                     {% elif body %}
                         {{ body | safe }}

--- a/templates/template_pages/case_template.html
+++ b/templates/template_pages/case_template.html
@@ -142,7 +142,7 @@
                     {{ description }}
                 </div>
 
-                {% if type and (type|lower).startswith('css') %}
+                {% if type and ((type|lower).startswith('css') or (type|lower).startswith('parameter-')) %}
                 <div class="interaction-box">
                     <h4 style="margin-top: 0; margin-bottom: 15px; display:flex; align-items:center; justify-content:space-between;">
                         <span><i class="fas fa-flask"></i> Test Your Payload</span>
@@ -174,7 +174,7 @@
                     
                     <div class="edu-note">
                         <i class="fas fa-info-circle" style="color: #007bff; margin-right: 5px;"></i> 
-                        <strong>How it works:</strong> The text you type above is appended to the URL as a GET parameter (<code>?q=...</code>). The server then takes this parameter and inserts it into the CSS code below.
+                        <strong>How it works:</strong> The text you type above is appended to the URL as a GET parameter (<code>?q=...</code>). The server then takes this parameter and inserts it into the HTML below without any escaping.
                     </div>
                 </div>
                 {% endif %}
@@ -227,6 +227,65 @@
                         </style>
 
                         <p id="cssFontTarget">This text will use the injected font-family.</p>
+
+                    {% elif type == "parameter-body" %}
+                        <h3>Body Injection</h3>
+                        <p>The <code>q</code> parameter is echoed directly within the <code>&lt;body&gt;</code> tag. No escaping is applied.</p>
+                        <p>Context: <code>&lt;body&gt; [INPUT] &lt;/body&gt;</code></p>
+
+                        <div style="margin: 20px 0; padding: 20px; border: 1px dashed #555; border-radius: 8px; background: rgba(255,255,255,0.02);">
+                            <p style="color: #888; font-size: 0.85em; margin-bottom: 10px;">⬇️ Reflected output:</p>
+                            {{ request.args.get('q', 'Hello World') | safe }}
+                        </div>
+
+                    {% elif type == "parameter-title" %}
+                        <h3>Title Tag Injection</h3>
+                        <p>The <code>q</code> parameter is echoed within the <code>&lt;title&gt;</code> tag. Check the browser tab to see the reflected value.</p>
+                        <p>Context: <code>&lt;title&gt; [INPUT] &lt;/title&gt;</code></p>
+
+                        <title>{{ request.args.get('q', 'XSStrange - Title Injection') | safe }}</title>
+
+                        <div style="margin: 20px 0; padding: 20px; border: 1px dashed #555; border-radius: 8px; background: rgba(255,255,255,0.02);">
+                            <p style="color: #888; font-size: 0.85em; margin-bottom: 10px;">⬇️ The parameter is injected into the <code>&lt;title&gt;</code> tag above. Check the browser tab title.</p>
+                            <p>Current title value: <code>{{ request.args.get('q', 'XSStrange - Title Injection') }}</code></p>
+                        </div>
+
+                    {% elif type == "parameter-body-comment" %}
+                        <h3>HTML Comment Injection</h3>
+                        <p>The <code>q</code> parameter is echoed inside an HTML comment in the body. The content is not visible, but it is in the source code.</p>
+                        <p>Context: <code>&lt;!-- [INPUT] --&gt;</code></p>
+
+                        <div style="margin: 20px 0; padding: 20px; border: 1px dashed #555; border-radius: 8px; background: rgba(255,255,255,0.02);">
+                            <p style="color: #888; font-size: 0.85em; margin-bottom: 10px;">⬇️ Reflected output (hidden in HTML comment — view page source):</p>
+                            <!-- {{ request.args.get('q', 'This is a comment') | safe }} -->
+                            <p style="color: #666; font-style: italic;">The input is inside an HTML comment. Right-click → View Page Source to see it.</p>
+                        </div>
+
+                    {% elif type == "parameter-attribute-unquoted" %}
+                        <h3>Unquoted Attribute Injection</h3>
+                        <p>The <code>q</code> parameter is echoed in an HTML attribute without quotes.</p>
+                        <p>Context: <code>&lt;div data-value=[INPUT]&gt;</code></p>
+
+                        <div style="margin: 20px 0; padding: 20px; border: 1px dashed #555; border-radius: 8px; background: rgba(255,255,255,0.02);">
+                            <p style="color: #888; font-size: 0.85em; margin-bottom: 10px;">⬇️ Reflected output (inspect the element below):</p>
+                            <div id="attrTarget" data-value={{ request.args.get('q', 'default') | safe }} style="padding: 15px; border: 1px solid #444; border-radius: 6px; background: rgba(0,255,157,0.05);">
+                                This element has <code>data-value={{ request.args.get('q', 'default') }}</code> (unquoted attribute).
+                                <br><em>Inspect this element to see the injection point.</em>
+                            </div>
+                        </div>
+
+                    {% elif type == "parameter-attribute-double-quoted" %}
+                        <h3>Double-Quoted Attribute Injection</h3>
+                        <p>The <code>q</code> parameter is echoed in a double-quoted HTML attribute.</p>
+                        <p>Context: <code>&lt;div data-value="[INPUT]"&gt;</code></p>
+
+                        <div style="margin: 20px 0; padding: 20px; border: 1px dashed #555; border-radius: 8px; background: rgba(255,255,255,0.02);">
+                            <p style="color: #888; font-size: 0.85em; margin-bottom: 10px;">⬇️ Reflected output (inspect the element below):</p>
+                            <div id="attrQuotedTarget" data-value="{{ request.args.get('q', 'default') | safe }}" style="padding: 15px; border: 1px solid #444; border-radius: 6px; background: rgba(0,255,157,0.05);">
+                                This element has <code>data-value="{{ request.args.get('q', 'default') }}"</code> (double-quoted attribute).
+                                <br><em>Inspect this element to see the injection point.</em>
+                            </div>
+                        </div>
 
                     {% elif body %}
                         {{ body | safe }}


### PR DESCRIPTION
## Description

Added 5 new reflected XSS test cases inspired by [Google Firing Range](https://github.com/google/firing-range)'s HTML Context category. These cover fundamental HTML injection contexts where the `q` parameter is echoed without any server-side escaping.

## New Cases

| Case | Injection Context | Difficulty |
|------|-------------------|------------|
| Parameter - Body | `<body> [INPUT] </body>` | Beginner |
| Parameter - Title | `<title> [INPUT] </title>` | Easy |
| Parameter - Body HTML Comment | `<!-- [INPUT] -->` | Medium |
| Parameter - Attribute Unquoted | `<div data-value=[INPUT]>` | Easy |
| Parameter - Attribute Double Quoted | `<div data-value="[INPUT]">` | Medium |

## Changes

- **5 new JSON case files** in `cases/reflected/`
- - **Updated `case_template.html`** with 5 new type handlers and interaction boxes
- - **Updated `index_cases.json`** with new case slugs
All cases use Jinja2 template rendering with `| safe` filter (no escaping), faithfully reproducing the firing-range injection patterns.